### PR TITLE
v0.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+
+examples/BRM-emot-submit.csv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rnltk"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Michael Long <michael.d.long88@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ readme = "README.md"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.86"
 regex = "1.6.0"
+csv = "1.1.6"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # rnltk
 This crate is designed to create a general tooklit for natural language processing, a current deficiency in the Rust ecosystem.  
 
-Current API: https://docs.rs/rnltk/
+Project can be found on [crates.io](https://crates.io/crates/rnltk).
+
+## Examples
+Check out the examples folder to see how to create a sentiment lexicon and get the arousal level for a term.
 
 ## Sentiment
 The sentiment analysis was originally designed by [Dr. Christopher Healey](https://www.csc.ncsu.edu/people/healey) and then ported
@@ -13,6 +16,8 @@ this to include stop word removal as well.
 
 ## Stem
 Stemming currently uses modified code from [rust-stem](https://github.com/minhnhdo/rust-stem), but this may switch to the [rust-stemmers](https://crates.io/crates/rust-stemmers) crate after further research.
+
+More information on the stemming algorithm can be found [here](https://tartarus.org/martin/PorterStemmer/).
 
 ## Roadmap
 * article summary (based on term frequency)

--- a/examples/lexicon_creation.rs
+++ b/examples/lexicon_creation.rs
@@ -1,0 +1,31 @@
+//! Create and add sentiment lexicon
+//! The data* contained in `BRM-emot-submit.csv` can be found at https://link.springer.com/article/10.3758/s13428-012-0314-x
+//! After downloading the data, simply update the file path in the below example
+//! 
+//! \* The data referenced here is only permitted to be used non-commercially
+
+use std::collections::HashMap;
+use rnltk::sentiment::{SentimentModel, CustomWords, SentimentDictValue};
+use rnltk::stem;
+
+
+fn main() {
+    // lexicon data pulled from https://link.springer.com/article/10.3758/s13428-012-0314-x
+    let mut reader = csv::Reader::from_path("examples/BRM-emot-submit.csv").unwrap();
+    let mut custom_words: CustomWords = HashMap::new();
+    for record in reader.records() {
+        let record = record.unwrap();
+        let word = record[1].to_owned();
+        let stemmed_word = stem::get(&word).unwrap();
+        if &word == "betrayal" {
+            println!("{:?}", &stemmed_word)
+        }
+        let avg = vec![record[2].parse::<f64>().unwrap(), record[5].parse::<f64>().unwrap()];
+        let std = vec![record[3].parse::<f64>().unwrap(), record[6].parse::<f64>().unwrap()];
+        let sentiment_dict = SentimentDictValue::new(word, stemmed_word, avg, std);
+        custom_words.insert(record[1].to_owned(), sentiment_dict);
+    }
+    
+    let sentiment = SentimentModel::new(custom_words);
+    println!("{:?}", sentiment.get_arousal_for_single_term("abduction"));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! the sentiment analysis is based on arousal and valence levels.
 //! 
 //! \* For anyone interested in a sentiment lexicon for non-commercial use, please check out the work of 
-//! [Warriner et al](https://link.springer.com/article/10.3758/s13428-012-0314-x) for an expanded ANEW lexicon. The
+//! [Warriner et al., 2013](https://link.springer.com/article/10.3758/s13428-012-0314-x) for an expanded ANEW lexicon. The
 //! data can be found in the "Electronic supplementary material" section of the paper. 
 //! 
 //! For example, this code takes a JSON string and then creates a [`CustomWords`] type from that serialized data. The CustomWords
@@ -47,6 +47,8 @@
 //! 
 //! let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
 //! ```
+//! 
+//! Checkout the examples folder in the github project repository for a more comprehensive example.
 //! 
 
 pub mod token;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! To start using RNLTK simply add the following to your Cargo.toml file:
 //! ```ignore
 //! [dependencies]
-//! rnltk = "0.1.2"
+//! rnltk = "0.1.3"
 //! ```
 //! 
 //! While this project provides the basic framework for natural language processing, it does require you to provide

--- a/src/stem.rs
+++ b/src/stem.rs
@@ -3,8 +3,8 @@
 use std::str;
 use crate::error::RnltkError;
 
-/// Member word is a vector of bytes holding a word to be stemmed.
-/// The letters are in word[0], word[1] ... ending at word[z->k]. Member k is readjusted
+/// `word` is a vector of bytes holding a word to be stemmed.
+/// The letters are in word[0], word[1] ... ending at word[z->`bytes_length`]. `bytes_length` is readjusted
 /// downwards as the stemming progresses. Zero termination is not in fact used
 /// in the algorithm.
 ///
@@ -47,23 +47,23 @@ impl Stemmer {
         }
     }
 
-    /// stem.is_consonant(i) is true <=> stem[i] is a consonant
+    /// stem.is_consonant(index) is true <=> stem[index] is a consonant
     #[inline]
-    fn is_consonant(&self, i: usize) -> bool {
-        match self.bytes[i] {
+    fn is_consonant(&self, index: usize) -> bool {
+        match self.bytes[index] {
             b'a' | b'e' | b'i' | b'o' | b'u' => false,
             b'y' => {
-                if i == 0 {
+                if index == 0 {
                     true
                 } else {
-                    !self.is_consonant(i - 1)
+                    !self.is_consonant(index - 1)
                 }
             }
             _ => true,
         }
     }
 
-    /// stem.measure() measures the number of consonant sequences in [0, j).
+    /// stem.measure() measures the number of consonant sequences in [0, offset).
     /// if c is a consonant sequence and v a vowel sequence, and <..> indicates
     /// arbitrary presence,
     ///
@@ -76,64 +76,64 @@ impl Stemmer {
     /// ~~~
     fn measure(&self) -> usize {
         let mut n = 0;
-        let mut i = 0;
-        let j = self.offset;
+        let mut index = 0;
+        let offset = self.offset;
         loop {
-            if i >= j {
+            if index >= offset {
                 return n;
             }
-            if !self.is_consonant(i) {
+            if !self.is_consonant(index) {
                 break;
             }
-            i += 1;
+            index += 1;
         }
-        i += 1;
+        index += 1;
         loop {
             loop {
-                if i >= j {
+                if index >= offset {
                     return n;
                 }
-                if self.is_consonant(i) {
+                if self.is_consonant(index) {
                     break;
                 }
-                i += 1;
+                index += 1;
             }
-            i += 1;
+            index += 1;
             n += 1;
             loop {
-                if i >= j {
+                if index >= offset {
                     return n;
                 }
-                if !self.is_consonant(i) {
+                if !self.is_consonant(index) {
                     break;
                 }
-                i += 1;
+                index += 1;
             }
-            i += 1;
+            index += 1;
         }
     }
 
-    /// stem.has_vowel() is TRUE <=> [0, j-1) contains a vowel
+    /// stem.has_vowel() is TRUE <=> [0, offset-1) contains a vowel
     fn has_vowel(&self) -> bool {
-        for i in 0..self.offset {
-            if !self.is_consonant(i) {
+        for index in 0..self.offset {
+            if !self.is_consonant(index) {
                 return true;
             }
         }
         false
     }
 
-    /// stem.double_consonant(i) is TRUE <=> i,(i-1) contain a double consonant.
+    /// stem.double_consonant(index) is TRUE <=> index,(index-1) contain a double consonant.
     #[inline]
-    fn double_consonant(&self, i: usize) -> bool {
-        if i < 1 || self.bytes[i] != self.bytes[i - 1] {
+    fn double_consonant(&self, index: usize) -> bool {
+        if index < 1 || self.bytes[index] != self.bytes[index - 1] {
             false
         } else {
-            self.is_consonant(i)
+            self.is_consonant(index)
         }
     }
 
-    /// cvc(z, i) is TRUE <=> i-2,i-1,i has the form consonant - vowel - consonant
+    /// cvc(z, index) is TRUE <=> index-2,index-1,index has the form consonant - vowel - consonant
     /// and also if the second c is not w,x or y. this is used when trying to
     /// restore an e at the end of a short word. e.g.
     ///
@@ -141,30 +141,33 @@ impl Stemmer {
     ///    cav(e), lov(e), hop(e), crim(e), but
     ///    snow, box, tray.
     /// ~~~
-    fn cvc(&self, i: usize) -> bool {
-        if i < 2 || !self.is_consonant(i) || self.is_consonant(i - 1) || !self.is_consonant(i - 2) {
+    fn cvc(&self, index: usize) -> bool {
+        if index < 2 || !self.is_consonant(index) || self.is_consonant(index - 1) || !self.is_consonant(index - 2) {
             false
         } else {
-            !matches!(self.bytes[i], b'w' | b'x' | b'y')
+            !matches!(self.bytes[index], b'w' | b'x' | b'y')
         }
     }
 
-    /// stem.ends(s) is true <=> [0, k) ends with the string s.
+    /// stem.ends(s) is true <=> [0, bytes_length) ends with the string s.
     fn ends(&mut self, _s: &str) -> bool {
         let s = _s.as_bytes();
         let len = s.len();
         if len > self.bytes_length {
             false
-        } else if &self.bytes[self.bytes_length - len..self.bytes_length] == s {
-            self.offset = self.bytes_length - len;
-            true
-        } else {
-            false
+        } else { 
+            &self.bytes[self.bytes_length - len..self.bytes_length] == s 
         }
     }
 
-    /// stem.setto(s) sets [j,k) to the characters in the string s,
-    /// readjusting k.
+    fn update_offset(&mut self, _s: &str) {
+        let s = _s.as_bytes();
+        let len = s.len();
+        self.offset = self.bytes_length - len;
+    }
+
+    /// stem.setto(s) sets [offset, bytes_length) to the characters in the string s,
+    /// readjusting bytes_length.
     fn set_to(&mut self, s: &str) {
         let s = s.as_bytes();
         let len = s.len();
@@ -206,41 +209,57 @@ impl Stemmer {
     fn step1ab(&mut self) {
         if self.bytes[self.bytes_length - 1] == b's' {
             if self.ends("sses") {
+                self.update_offset("sses");
                 self.bytes_length -= 2;
             } else if self.ends("ies") {
+                self.update_offset("ies");
                 self.set_to("i");
             } else if self.bytes[self.bytes_length - 2] != b's' {
                 self.bytes_length -= 1;
             }
         }
         if self.ends("eed") {
+            self.update_offset("eed");
             if self.measure() > 0 {
                 self.bytes_length -= 1
             }
-        } else if (self.ends("ed") || self.ends("ing")) && self.has_vowel() {
-            self.bytes_length = self.offset;
-            if self.ends("at") {
-                self.set_to("ate");
-            } else if self.ends("bl") {
-                self.set_to("ble");
-            } else if self.ends("iz") {
-                self.set_to("ize");
-            } else if self.double_consonant(self.bytes_length - 1) {
-                self.bytes_length -= 1;
-                match self.bytes[self.bytes_length - 1] {
-                    b'l' | b's' | b'z' => self.bytes_length += 1,
-                    _ => (),
+        } else if self.ends("ed") || self.ends("ing") {
+            if self.ends("ed") {
+                self.update_offset("ed");
+            } else if self.ends("ing") {
+                self.update_offset("ing");
+            }
+            if self.has_vowel() {
+                self.bytes_length = self.offset;
+                if self.ends("at") {
+                    self.update_offset("at");
+                    self.set_to("ate");
+                } else if self.ends("bl") {
+                    self.update_offset("bl");
+                    self.set_to("ble");
+                } else if self.ends("iz") {
+                    self.update_offset("iz");
+                    self.set_to("ize");
+                } else if self.double_consonant(self.bytes_length - 1) {
+                    self.bytes_length -= 1;
+                    match self.bytes[self.bytes_length - 1] {
+                        b'l' | b's' | b'z' => self.bytes_length += 1,
+                        _ => (),
+                    }
+                } else if self.measure() == 1 && self.cvc(self.bytes_length - 1) {
+                    self.set_to("e");
                 }
-            } else if self.measure() == 1 && self.cvc(self.bytes_length - 1) {
-                self.set_to("e");
             }
         }
     }
 
     /// stem.step1c() turns terminal y to i when there is another vowel in the stem.
     fn step1c(&mut self) {
-        if self.ends("y") && self.has_vowel() {
-            self.bytes[self.bytes_length - 1] = b'i';
+        if self.ends("y") {
+            self.update_offset("y");
+            if self.has_vowel() {
+                self.bytes[self.bytes_length - 1] = b'i';
+            }
         }
     }
 
@@ -251,107 +270,94 @@ impl Stemmer {
         match self.bytes[self.bytes_length - 2] {
             b'a' => {
                 if self.ends("ational") {
+                    self.update_offset("ational");
                     self.replace("ate");
-                    return;
-                }
-                if self.ends("tional") {
+                } else if self.ends("tional") {
+                    self.update_offset("tional");
                     self.replace("tion");
-                    return;
                 }
             }
             b'c' => {
                 if self.ends("enci") {
+                    self.update_offset("enci");
                     self.replace("ence");
-                    return;
-                }
-                if self.ends("anci") {
+                } else if self.ends("anci") {
+                    self.update_offset("anci");
                     self.replace("ance");
-                    return;
                 }
             }
             b'e' => {
                 if self.ends("izer") {
+                    self.update_offset("izer");
                     self.replace("ize");
-                    return;
                 }
             }
             b'l' => {
                 if self.ends("bli") {
+                    self.update_offset("bli");
                     self.replace("ble");
-                    return;
                 } /*-DEPARTURE-*/
 
                 /* To match the published algorithm, replace this line with
                 'l' => {
                     if self.ends("abli") { self.replace("able"); return } */
-
-                if self.ends("alli") {
+                else if self.ends("alli") {
+                    self.update_offset("alli");
                     self.replace("al");
-                    return;
-                }
-                if self.ends("entli") {
+                } else if self.ends("entli") {
+                    self.update_offset("entli");
                     self.replace("ent");
-                    return;
-                }
-                if self.ends("eli") {
+                } else if self.ends("eli") {
+                    self.update_offset("eli");
                     self.replace("e");
-                    return;
-                }
-                if self.ends("ousli") {
+                } else if self.ends("ousli") {
+                    self.update_offset("ousli");
                     self.replace("ous");
-                    return;
                 }
             }
             b'o' => {
                 if self.ends("ization") {
+                    self.update_offset("ization");
                     self.replace("ize");
-                    return;
-                }
-                if self.ends("ation") {
+                } else if self.ends("ation") {
+                    self.update_offset("ation");
                     self.replace("ate");
-                    return;
-                }
-                if self.ends("ator") {
+                } else if self.ends("ator") {
+                    self.update_offset("ator");
                     self.replace("ate");
-                    return;
                 }
             }
             b's' => {
                 if self.ends("alism") {
+                    self.update_offset("alism");
                     self.replace("al");
-                    return;
-                }
-                if self.ends("iveness") {
+                } else if self.ends("iveness") {
+                    self.update_offset("iveness");
                     self.replace("ive");
-                    return;
-                }
-                if self.ends("fulness") {
+                } else if self.ends("fulness") {
+                    self.update_offset("fulness");
                     self.replace("ful");
-                    return;
-                }
-                if self.ends("ousness") {
+                } else if self.ends("ousness") {
+                    self.update_offset("ousness");
                     self.replace("ous");
-                    return;
                 }
             }
             b't' => {
                 if self.ends("aliti") {
+                    self.update_offset("aliti");
                     self.replace("al");
-                    return;
-                }
-                if self.ends("iviti") {
+                } else if self.ends("iviti") {
+                    self.update_offset("iviti");
                     self.replace("ive");
-                    return;
-                }
-                if self.ends("biliti") {
+                } else if self.ends("biliti") {
+                    self.update_offset("biliti");
                     self.replace("ble");
-                    return;
                 }
             }
             b'g' => {
                 if self.ends("logi") {
+                    self.update_offset("logi");
                     self.replace("log");
-                    return;
                 }
             } /*-DEPARTURE-*/
             /* To match the published algorithm, delete this line */
@@ -364,38 +370,35 @@ impl Stemmer {
         match self.bytes[self.bytes_length - 1] {
             b'e' => {
                 if self.ends("icate") {
+                    self.update_offset("icate");
                     self.replace("ic");
-                    return;
-                }
-                if self.ends("ative") {
+                } else if self.ends("ative") {
+                    self.update_offset("ative");
                     self.replace("");
-                    return;
-                }
-                if self.ends("alize") {
+                } else if self.ends("alize") {
+                    self.update_offset("alize");
                     self.replace("al");
-                    return;
                 }
             }
             b'i' => {
                 if self.ends("iciti") {
+                    self.update_offset("iciti");
                     self.replace("ic");
-                    return;
                 }
             }
             b'l' => {
                 if self.ends("ical") {
+                    self.update_offset("ical");
                     self.replace("ic");
-                    return;
-                }
-                if self.ends("ful") {
+                } else if self.ends("ful") {
+                    self.update_offset("ful");
                     self.replace("");
-                    return;
                 }
             }
             b's' => {
                 if self.ends("ness") {
+                    self.update_offset("ness");
                     self.replace("");
-                    return;
                 }
             }
             _ => (),
@@ -404,83 +407,107 @@ impl Stemmer {
 
     /// stem.step4() takes off -ant, -ence etc., in context <c>vcvc<v>.
     fn step4(&mut self) {
+        let mut byte_was_matched = false;
         match self.bytes[self.bytes_length - 2] {
             b'a' => {
                 if self.ends("al") {
-                } else {
-                    return;
+                    self.update_offset("al");
+                    byte_was_matched = true;
                 }
             }
             b'c' => {
-                if self.ends("ance") || self.ends("ence") {
-                } else {
-                    return;
+                if self.ends("ance") {
+                    self.update_offset("ance");
+                    byte_was_matched = true;
+                } else if self.ends("ence") {
+                    self.update_offset("ence");
+                    byte_was_matched = true;
                 }
             }
             b'e' => {
                 if self.ends("er") {
-                } else {
-                    return;
+                    self.update_offset("er");
+                    byte_was_matched = true;
                 }
             }
             b'i' => {
                 if self.ends("ic") {
-                } else {
-                    return;
+                    self.update_offset("ic");
+                    byte_was_matched = true;
                 }
             }
             b'l' => {
-                if self.ends("able") || self.ends("ible") {
-                } else {
-                    return;
+                if self.ends("able") {
+                    self.update_offset("able");
+                    byte_was_matched = true;
+                } else if self.ends("ible") {
+                    self.update_offset("ible");
+                    byte_was_matched = true;
                 }
             }
             b'n' => {
-                if self.ends("ant") || self.ends("ement") || self.ends("ment") || self.ends("ent") {
-                } else {
-                    return;
+                if self.ends("ant") {
+                    self.update_offset("ant");
+                    byte_was_matched = true;
+                } else if self.ends("ement") {
+                    self.update_offset("ement");
+                    byte_was_matched = true;
+                } else if self.ends("ment") {
+                    self.update_offset("ment");
+                    byte_was_matched = true;
+                } else if self.ends("ent") {
+                    self.update_offset("ent");
+                    byte_was_matched = true;
                 }
             }
             b'o' => {
-                if self.ends("ion") && (self.bytes[self.offset - 1] == b's' || self.bytes[self.offset - 1] == b't') || self.ends("ou") {
-                } else {
-                    return;
+                if self.ends("ion") {
+                    self.update_offset("ion");
+                    if self.offset > 0 && (self.bytes[self.offset - 1] == b's' || self.bytes[self.offset - 1] == b't') {
+                        byte_was_matched = true;
+                    }
+                } else if self.ends("ou") {
+                    self.update_offset("ou");
+                    byte_was_matched = true;
                 }
                 /* takes care of -ous */
             }
             b's' => {
                 if self.ends("ism") {
-                } else {
-                    return;
+                    self.update_offset("ism");
+                    byte_was_matched = true;
                 }
             }
             b't' => {
-                if self.ends("ate") || self.ends("iti") {
-                } else {
-                    return;
+                if self.ends("ate") {
+                    self.update_offset("ate");
+                    byte_was_matched = true;
+                } else if self.ends("iti") {
+                    self.update_offset("iti");
+                    byte_was_matched = true;
                 }
             }
             b'u' => {
                 if self.ends("ous") {
-                } else {
-                    return;
+                    self.update_offset("ous");
+                    byte_was_matched = true;
                 }
             }
             b'v' => {
                 if self.ends("ive") {
-                } else {
-                    return;
+                    self.update_offset("ive");
+                    byte_was_matched = true;
                 }
             }
             b'z' => {
                 if self.ends("ize") {
-                } else {
-                    return;
+                    self.update_offset("ize");
+                    byte_was_matched = true;
                 }
             }
             _ => return,
         }
-        if self.measure() > 1 {
+        if byte_was_matched && self.measure() > 1 {
             self.bytes_length = self.offset
         }
     }

--- a/src/stem.rs
+++ b/src/stem.rs
@@ -3,29 +3,6 @@
 use std::str;
 use crate::error::RnltkError;
 
-/// `word` is a vector of bytes holding a word to be stemmed.
-/// The letters are in word[0], word[1] ... ending at word[z->`bytes_length`]. `bytes_length` is readjusted
-/// downwards as the stemming progresses. Zero termination is not in fact used
-/// in the algorithm.
-///
-/// Note that only lower case sequences are stemmed. get(...) automatically
-/// lowercases the string before processing.
-///
-///
-/// Typical usage is:
-/// 
-///```
-/// use rnltk::stem;
-/// # use rnltk::error::RnltkError;
-/// 
-/// # fn main() -> Result<(), RnltkError> {
-/// let word = "pencils";
-/// let stemmed_word = stem::get(word)?;
-/// assert_eq!(stemmed_word, "pencil".to_string());
-/// #
-/// #   Ok(())
-/// # }
-///```
 struct Stemmer {
     bytes: Vec<u8>,
     bytes_length: usize,
@@ -533,6 +510,29 @@ impl Stemmer {
     }
 }
 
+/// `word` is a vector of bytes holding a word to be stemmed.
+/// The letters are in word[0], word[1] ... ending at word[z -> bytes length]. Bytes length is readjusted
+/// downwards as the stemming progresses. Zero termination is not in fact used
+/// in the algorithm.
+///
+/// Note that only lower case sequences are stemmed. get(...) automatically
+/// lowercases the string before processing.
+///
+///
+/// Typical usage is:
+/// 
+///```
+/// use rnltk::stem;
+/// # use rnltk::error::RnltkError;
+/// 
+/// # fn main() -> Result<(), RnltkError> {
+/// let word = "pencils";
+/// let stemmed_word = stem::get(word)?;
+/// assert_eq!(stemmed_word, "pencil".to_string());
+/// #
+/// #   Ok(())
+/// # }
+///```
 pub fn get(word: &str) -> Result<String, RnltkError> {
     if word.len() > 2 {
         let mut mw = Stemmer::new(word)?;

--- a/test_data/output.txt
+++ b/test_data/output.txt
@@ -11056,6 +11056,7 @@ inward
 inwardli
 inward
 inward
+ion
 ionia
 ionian
 ips

--- a/test_data/voc.txt
+++ b/test_data/voc.txt
@@ -11056,6 +11056,7 @@ inward
 inwardly
 inwardness
 inwards
+ion
 ionia
 ionian
 ipse


### PR DESCRIPTION
This version:
- Adds a comprehensive example of creating a new sentiment lexicon, using it to instantiate a `SentimentModel`, and then getting the arousal level of a term
- Updates some of `stem` module documentation
- Fixes an issue in the `stem` module where the `ends` function had multiple responsibilities
- Fixes an issue in the `stem` module where the `get` function broke on the word "ion"