### PR TITLE
v0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rnltk"
-version = "0.1.3"
+version = "0.1.5"
 authors = ["Michael Long <michael.d.long88@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.86"
 regex = "1.6.0"
 csv = "1.1.6"
+thiserror = "1.0.37"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,16 @@
 //! Error type for when a sentiment term already exists in the sentiment lexicon when adding a new term
 //! or for when stemming a word with non-ASCII characters
 
-#[derive(Debug, PartialEq, Eq)]
+use thiserror::Error;
+
+
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum RnltkError {
     /// An existing sentiment term could not be added to the lexicon since it was attempted
     /// without replacement
+    #[error("Attempted to add existing key without replacement")]
     SentimentTermExists,
     /// Could not stem a term due to non-ASCII characters
+    #[error("Could not stem term due to non-ASCII characters present")]
     StemNonAscii
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! ## Getting Started
 //!
 //! To start using RNLTK simply add the following to your Cargo.toml file:
-//! ```ignore
+//! ```toml
 //! [dependencies]
 //! rnltk = "0.1.3"
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,15 +33,15 @@
 //! ```
 //! use rnltk::sentiment::{SentimentModel, CustomWords};
 //! 
-//! let custom_word_dict = "
+//! let custom_word_dict = r#"
 //! {
-//!     \"abduction\": {
-//!         \"word\": \"abduction\",
-//!         \"stem\": \"abduct\",
-//!         \"avg\": [2.76, 5.53],
-//!         \"std\": [2.06, 2.43]
+//!     "abduction": {
+//!         "word": "abduction",
+//!         "stem": "abduct",
+//!         "avg": [2.76, 5.53],
+//!         "std": [2.06, 2.43]
 //!     }
-//! }";
+//! }"#;
 //! 
 //! let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
 //! 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,3 +55,4 @@ pub mod token;
 pub mod sentiment;
 pub mod stem;
 pub mod error;
+pub mod sample_data;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! To start using RNLTK simply add the following to your Cargo.toml file:
 //! ```toml
 //! [dependencies]
-//! rnltk = "0.1.3"
+//! rnltk = "0.1.5"
 //! ```
 //! 
 //! While this project provides the basic framework for natural language processing, it does require you to provide

--- a/src/sample_data.rs
+++ b/src/sample_data.rs
@@ -1,0 +1,28 @@
+use crate::sentiment::CustomWords;
+
+
+pub fn get_sample_custom_word_dict() -> CustomWords {
+    let custom_word_dict = r#"
+    {
+        "abduction": {
+            "word": "abduction",
+            "stem": "abduct",
+            "avg": [2.76, 5.53],
+            "std": [2.06, 2.43]
+        },
+        "betrayed": {
+            "word": "betrayed",
+            "stem": "betrai",
+            "avg": [2.57, 7.24],
+            "std": [1.83, 2.06]
+        },
+        "bees": {
+            "word": "bees",
+            "stem": "bee",
+            "avg": [3.2, 6.51],
+            "std": [2.07, 2.14]
+        }
+    }"#;
+
+    serde_json::from_str(custom_word_dict).unwrap()
+}

--- a/src/sample_data.rs
+++ b/src/sample_data.rs
@@ -1,3 +1,8 @@
+//! Module containing function to get [`CustomWords`] struct primarily
+//! for the use in documentation.
+//! 
+//! [`CustomWords`]: ./sentiment/type.CustomWords.html
+
 use crate::sentiment::CustomWords;
 
 

--- a/src/sentiment.rs
+++ b/src/sentiment.rs
@@ -11,6 +11,8 @@ use crate::error::RnltkError;
 pub type CustomWords = HashMap<String, SentimentDictValue>;
 pub type CustomStems = HashMap<String, SentimentDictValue>;
 
+/// Struct for holding raw arousal and sentiment values for
+/// `average` and `standard_deviation`.
 #[derive(Debug, PartialEq)]
 pub struct RawSentiment {
     pub average: f64,
@@ -58,11 +60,8 @@ pub struct SentimentModel {
 }
 
 impl SentimentModel {
-    /// Creates new instance of SentimentModel
-    /// 
-    /// # Arguments
-    /// 
-    /// * `custom_words` - CustomWords representation of sentiment lexicon
+    /// Creates new instance of SentimentModel from `custom_words`, a [`CustomWords`]
+    /// sentiment lexicon.
     ///
     /// # Examples
     ///
@@ -95,11 +94,7 @@ impl SentimentModel {
         }
     }
 
-    /// Adds new lexicon of stemmed words
-    /// 
-    /// # Arguments
-    /// 
-    /// * `custom_stems` - CustomStems representation of sentiment lexicon
+    /// Adds new `custom_stems` lexicon of stemmed words.
     ///
     /// # Examples
     ///
@@ -130,11 +125,7 @@ impl SentimentModel {
         self.custom_stems = custom_stems        
     }
 
-    /// Checks if a term exists in the sentiment dictionaries
-    /// 
-    /// # Arguments
-    /// 
-    /// * `term` - &str representation of the word token 
+    /// Checks if a `term` exists in the sentiment dictionaries.
     ///
     /// # Examples
     ///
@@ -153,11 +144,7 @@ impl SentimentModel {
         self.custom_words.contains_key(term) || self.custom_stems.contains_key(term)
     }
 
-    /// Gets the raw arousal values (average, standard deviation) for a given term
-    /// 
-    /// # Arguments
-    /// 
-    /// * `term` - &str representation of the word token 
+    /// Gets the raw arousal values ([`RawSentiment`]) for a given `term` word token.
     ///
     /// # Examples
     ///
@@ -191,11 +178,7 @@ impl SentimentModel {
         RawSentiment::new(average, std_dev)
     }
 
-    /// Gets the raw valence values (average, standard deviation) for a given term
-    /// 
-    /// # Arguments
-    /// 
-    /// * `term` - &str representation of the word token 
+    /// Gets the raw valence values ([`RawSentiment`]) for a given `term` word token.
     ///
     /// # Examples
     ///
@@ -229,11 +212,7 @@ impl SentimentModel {
         RawSentiment::new(average, std_dev)
     }
 
-    /// Gets the arousal value for a given term
-    /// 
-    /// # Arguments
-    /// 
-    /// * `term` - &str representation of the word token 
+    /// Gets the arousal value for a given `term` word token.
     ///
     /// # Examples
     ///
@@ -253,11 +232,7 @@ impl SentimentModel {
         self.get_raw_arousal(term).average
     }
 
-    /// Gets the valence value for a given term
-    /// 
-    /// # Arguments
-    /// 
-    /// * `term` - &str representation of the word token 
+    /// Gets the valence value for a given `term` word token.
     ///
     /// # Examples
     ///
@@ -277,11 +252,7 @@ impl SentimentModel {
         self.get_raw_valence(term).average
     }
 
-    /// Gets the arousal value for a given vector of terms
-    /// 
-    /// # Arguments
-    /// 
-    /// * `terms` - &Vec<&str> representation of the word tokens
+    /// Gets the arousal value for a word token vector of `terms`.
     ///
     /// # Examples
     ///
@@ -336,11 +307,7 @@ impl SentimentModel {
         arousal
     }
 
-    /// Gets the valence value for a given vector of terms
-    /// 
-    /// # Arguments
-    /// 
-    /// * `terms` - &Vec<&str> representation of the word tokens
+    /// Gets the valence value for a word token vector of `terms`.
     ///
     /// # Examples
     ///
@@ -395,11 +362,7 @@ impl SentimentModel {
         valence
     }
 
-    /// Gets the valence, arousal sentiment for a term
-    /// 
-    /// # Arguments
-    /// 
-    /// * `term` - &str representation of the word token
+    /// Gets the valence, arousal sentiment for a `term` word token.
     ///
     /// # Examples
     ///
@@ -424,11 +387,7 @@ impl SentimentModel {
         sentiment
     }
 
-    /// Gets the valence, arousal sentiment for a vector of terms
-    /// 
-    /// # Arguments
-    /// 
-    /// * `terms` - &Vec<&str> representation of the word tokens
+    /// Gets the valence, arousal sentiment for a word token vector of `terms`.
     ///
     /// # Examples
     ///
@@ -467,12 +426,7 @@ impl SentimentModel {
         sentiment
     }
 
-    /// Gets the Russel-like description given a valence and arousal score
-    /// 
-    /// # Arguments
-    /// 
-    /// * `valence` - &f64 valence score
-    /// * `arousal` - &f64 arousal score
+    /// Gets the Russel-like description given `valence` and `arousal` scores.
     ///
     /// # Examples
     ///
@@ -512,7 +466,7 @@ impl SentimentModel {
             "tense", "nervous", "stressed", "upset"
         ];
 
-        // Normalize valence and arousal, use polar coordinates to get angle
+        // Normalize valence and arousal, using polar coordinates to get angle
         // clockwise along bottom, counterclockwise along top
         let normalized_valence = ((valence - 1.0) - 4.0) / 4.0;
         let normalized_arousal = ((arousal - 1.0) - 4.0) / 4.0;
@@ -557,11 +511,7 @@ impl SentimentModel {
         Cow::from("unknown")
     }
 
-    /// Gets the Russel-like description given a term
-    /// 
-    /// # Arguments
-    /// 
-    /// * `term` - &str representation of the word token
+    /// Gets the Russel-like description given a `term` word token.
     ///
     /// # Examples
     ///
@@ -586,11 +536,7 @@ impl SentimentModel {
         self.get_sentiment_description(sentiment.get("valence").unwrap(), sentiment.get("arousal").unwrap())
     }
 
-    /// Gets the Russel-like description given a vector of terms
-    /// 
-    /// # Arguments
-    /// 
-    /// * `terms` - &Vec<&str> representation of the word tokens
+    /// Gets the Russel-like description given a word token vector of `terms`.
     ///
     /// # Examples
     ///
@@ -628,14 +574,9 @@ impl SentimentModel {
         self.get_sentiment_description(sentiment.get("valence").unwrap(), sentiment.get("arousal").unwrap())
     }
 
-    /// Adds a new term to the sentiment lexicons. If the term does not already exist, it 
+    /// Adds a new `term` word token with its corresponding `valence` and `arousal`
+    /// values to the sentiment lexicons. If the `term` does not already exist, it 
     /// will be added to the custom sentiment lexicon.
-    /// 
-    /// # Arguments
-    /// 
-    /// * `term` - &str representation of the word token
-    /// * `valence` - &f64 valence value
-    /// * `arousal` - &f64 arousal value
     /// 
     /// # Errors
     /// 
@@ -691,19 +632,14 @@ impl SentimentModel {
         Ok(())
     }
     
-    /// Adds a new term to the sentiment lexicons. If this terms already exists, the term will be updated
-    /// with the new valence and arousal values. If the term does not already exist, the term will be
-    /// stemmed and added to the custom sentiment lexicon. 
-    /// 
-    /// # Arguments
-    /// 
-    /// * `term` - &str representation of the word token
-    /// * `valence` - &f64 valence value
-    /// * `arousal` - &f64 arousal value
+    /// Adds a new `term` word token and its corresponding `valence` and `arousal`
+    /// values to the sentiment lexicons. If this `term` already exists, the `term` will be updated
+    /// with the new `valence` and `arousal` values. If the `term` does not already exist, the `term` will be
+    /// stemmed and added to the custom sentiment lexicon.
     ///
     /// # Errors
     /// 
-    /// Returns [`RnltkError::StemNonAscii`] in the event that the term being stemmed contains non-ASCII characters (like hopè).
+    /// Returns [`RnltkError::StemNonAscii`] in the event that the `term` being stemmed contains non-ASCII characters (like hopè).
     /// 
     /// # Examples
     ///

--- a/src/sentiment.rs
+++ b/src/sentiment.rs
@@ -54,15 +54,15 @@ impl SentimentModel {
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"abduction\": {
-    ///         \"word\": \"abduction\",
-    ///         \"stem\": \"abduct\",
-    ///         \"avg\": [2.76, 5.53],
-    ///         \"std\": [2.06, 2.43]
+    ///     "abduction": {
+    ///         "word": "abduction",
+    ///         "stem": "abduct",
+    ///         "avg": [2.76, 5.53],
+    ///         "std": [2.06, 2.43]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -91,26 +91,26 @@ impl SentimentModel {
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords, CustomStems};
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"abduction\": {
-    ///         \"word\": \"abduction\",
-    ///         \"stem\": \"abduct\",
-    ///         \"avg\": [2.76, 5.53],
-    ///         \"std\": [2.06, 2.43]
+    ///     "abduction": {
+    ///         "word": "abduction",
+    ///         "stem": "abduct",
+    ///         "avg": [2.76, 5.53],
+    ///         "std": [2.06, 2.43]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
-    /// let custom_stem_dict = "
+    /// let custom_stem_dict = r#"
     /// {
-    ///     \"abduct\": {
-    ///         \"word\": \"abduction\",
-    ///         \"stem\": \"abduct\",
-    ///         \"avg\": [2.76, 5.53],
-    ///         \"std\": [2.06, 2.43]
+    ///     "abduct": {
+    ///         "word": "abduction",
+    ///         "stem": "abduct",
+    ///         "avg": [2.76, 5.53],
+    ///         "std": [2.06, 2.43]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_stems_sentiment_hashmap: CustomStems = serde_json::from_str(custom_stem_dict).unwrap();
     /// 
     /// let mut sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -134,15 +134,15 @@ impl SentimentModel {
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"abduction\": {
-    ///         \"word\": \"abduction\",
-    ///         \"stem\": \"abduct\",
-    ///         \"avg\": [2.76, 5.53],
-    ///         \"std\": [2.06, 2.43]
+    ///     "abduction": {
+    ///         "word": "abduction",
+    ///         "stem": "abduct",
+    ///         "avg": [2.76, 5.53],
+    ///         "std": [2.06, 2.43]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -165,15 +165,15 @@ impl SentimentModel {
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"abduction\": {
-    ///         \"word\": \"abduction\",
-    ///         \"stem\": \"abduct\",
-    ///         \"avg\": [2.76, 5.53],
-    ///         \"std\": [2.06, 2.43]
+    ///     "abduction": {
+    ///         "word": "abduction",
+    ///         "stem": "abduct",
+    ///         "avg": [2.76, 5.53],
+    ///         "std": [2.06, 2.43]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -211,15 +211,15 @@ impl SentimentModel {
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"abduction\": {
-    ///         \"word\": \"abduction\",
-    ///         \"stem\": \"abduct\",
-    ///         \"avg\": [2.76, 5.53],
-    ///         \"std\": [2.06, 2.43]
+    ///     "abduction": {
+    ///         "word": "abduction",
+    ///         "stem": "abduct",
+    ///         "avg": [2.76, 5.53],
+    ///         "std": [2.06, 2.43]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -257,15 +257,15 @@ impl SentimentModel {
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"abduction\": {
-    ///         \"word\": \"abduction\",
-    ///         \"stem\": \"abduct\",
-    ///         \"avg\": [2.76, 5.53],
-    ///         \"std\": [2.06, 2.43]
+    ///     "abduction": {
+    ///         "word": "abduction",
+    ///         "stem": "abduct",
+    ///         "avg": [2.76, 5.53],
+    ///         "std": [2.06, 2.43]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -289,15 +289,15 @@ impl SentimentModel {
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"abduction\": {
-    ///         \"word\": \"abduction\",
-    ///         \"stem\": \"abduct\",
-    ///         \"avg\": [2.76, 5.53],
-    ///         \"std\": [2.06, 2.43]
+    ///     "abduction": {
+    ///         "word": "abduction",
+    ///         "stem": "abduct",
+    ///         "avg": [2.76, 5.53],
+    ///         "std": [2.06, 2.43]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -321,21 +321,21 @@ impl SentimentModel {
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"betrayed\": {
-    ///         \"word\": \"betrayed\",
-    ///         \"stem\": \"betrai\",
-    ///         \"avg\": [2.57, 7.24],
-    ///         \"std\": [1.83, 2.06]
+    ///     "betrayed": {
+    ///         "word": "betrayed",
+    ///         "stem": "betrai",
+    ///         "avg": [2.57, 7.24],
+    ///         "std": [1.83, 2.06]
     ///     },
-    ///     \"bees\": {
-    ///         \"word\": \"bees\",
-    ///         \"stem\": \"bee\",
-    ///         \"avg\": [3.2, 6.51],
-    ///         \"std\": [2.07, 2.14]
+    ///     "bees": {
+    ///         "word": "bees",
+    ///         "stem": "bee",
+    ///         "avg": [3.2, 6.51],
+    ///         "std": [2.07, 2.14]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -380,21 +380,21 @@ impl SentimentModel {
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"betrayed\": {
-    ///         \"word\": \"betrayed\",
-    ///         \"stem\": \"betrai\",
-    ///         \"avg\": [2.57, 7.24],
-    ///         \"std\": [1.83, 2.06]
+    ///     "betrayed": {
+    ///         "word": "betrayed",
+    ///         "stem": "betrai",
+    ///         "avg": [2.57, 7.24],
+    ///         "std": [1.83, 2.06]
     ///     },
-    ///     \"bees\": {
-    ///         \"word\": \"bees\",
-    ///         \"stem\": \"bee\",
-    ///         \"avg\": [3.2, 6.51],
-    ///         \"std\": [2.07, 2.14]
+    ///     "bees": {
+    ///         "word": "bees",
+    ///         "stem": "bee",
+    ///         "avg": [3.2, 6.51],
+    ///         "std": [2.07, 2.14]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -440,15 +440,15 @@ impl SentimentModel {
     /// use std::collections::HashMap;
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"abduction\": {
-    ///         \"word\": \"abduction\",
-    ///         \"stem\": \"abduct\",
-    ///         \"avg\": [2.76, 5.53],
-    ///         \"std\": [2.06, 2.43]
+    ///     "abduction": {
+    ///         "word": "abduction",
+    ///         "stem": "abduct",
+    ///         "avg": [2.76, 5.53],
+    ///         "std": [2.06, 2.43]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -477,21 +477,21 @@ impl SentimentModel {
     /// use std::collections::HashMap;
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"betrayed\": {
-    ///         \"word\": \"betrayed\",
-    ///         \"stem\": \"betrai\",
-    ///         \"avg\": [2.57, 7.24],
-    ///         \"std\": [1.83, 2.06]
+    ///     "betrayed": {
+    ///         "word": "betrayed",
+    ///         "stem": "betrai",
+    ///         "avg": [2.57, 7.24],
+    ///         "std": [1.83, 2.06]
     ///     },
-    ///     \"bees\": {
-    ///         \"word\": \"bees\",
-    ///         \"stem\": \"bee\",
-    ///         \"avg\": [3.2, 6.51],
-    ///         \"std\": [2.07, 2.14]
+    ///     "bees": {
+    ///         "word": "bees",
+    ///         "stem": "bee",
+    ///         "avg": [3.2, 6.51],
+    ///         "std": [2.07, 2.14]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -520,15 +520,15 @@ impl SentimentModel {
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"abduction\": {
-    ///         \"word\": \"abduction\",
-    ///         \"stem\": \"abduct\",
-    ///         \"avg\": [2.76, 5.53],
-    ///         \"std\": [2.06, 2.43]
+    ///     "abduction": {
+    ///         "word": "abduction",
+    ///         "stem": "abduct",
+    ///         "avg": [2.76, 5.53],
+    ///         "std": [2.06, 2.43]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -618,15 +618,15 @@ impl SentimentModel {
     /// use std::collections::HashMap;
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"abduction\": {
-    ///         \"word\": \"abduction\",
-    ///         \"stem\": \"abduct\",
-    ///         \"avg\": [2.76, 5.53],
-    ///         \"std\": [2.06, 2.43]
+    ///     "abduction": {
+    ///         "word": "abduction",
+    ///         "stem": "abduct",
+    ///         "avg": [2.76, 5.53],
+    ///         "std": [2.06, 2.43]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -654,21 +654,21 @@ impl SentimentModel {
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"betrayed\": {
-    ///         \"word\": \"betrayed\",
-    ///         \"stem\": \"betrai\",
-    ///         \"avg\": [2.57, 7.24],
-    ///         \"std\": [1.83, 2.06]
+    ///     "betrayed": {
+    ///         "word": "betrayed",
+    ///         "stem": "betrai",
+    ///         "avg": [2.57, 7.24],
+    ///         "std": [1.83, 2.06]
     ///     },
-    ///     \"bees\": {
-    ///         \"word\": \"bees\",
-    ///         \"stem\": \"bee\",
-    ///         \"avg\": [3.2, 6.51],
-    ///         \"std\": [2.07, 2.14]
+    ///     "bees": {
+    ///         "word": "bees",
+    ///         "stem": "bee",
+    ///         "avg": [3.2, 6.51],
+    ///         "std": [2.07, 2.14]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -705,15 +705,15 @@ impl SentimentModel {
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// use rnltk::error::RnltkError;
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"abduction\": {
-    ///         \"word\": \"abduction\",
-    ///         \"stem\": \"abduct\",
-    ///         \"avg\": [2.76, 5.53],
-    ///         \"std\": [2.06, 2.43]
+    ///     "abduction": {
+    ///         "word": "abduction",
+    ///         "stem": "abduct",
+    ///         "avg": [2.76, 5.53],
+    ///         "std": [2.06, 2.43]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let mut sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
@@ -777,15 +777,15 @@ impl SentimentModel {
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// use rnltk::error::RnltkError;
     /// 
-    /// let custom_word_dict = "
+    /// let custom_word_dict = r#"
     /// {
-    ///     \"abduction\": {
-    ///         \"word\": \"abduction\",
-    ///         \"stem\": \"abduct\",
-    ///         \"avg\": [2.76, 5.53],
-    ///         \"std\": [2.06, 2.43]
+    ///     "abduction": {
+    ///         "word": "abduction",
+    ///         "stem": "abduct",
+    ///         "avg": [2.76, 5.53],
+    ///         "std": [2.06, 2.43]
     ///     }
-    /// }";
+    /// }"#;
     /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
     /// 
     /// let mut sentiment = SentimentModel::new(custom_words_sentiment_hashmap);

--- a/src/sentiment.rs
+++ b/src/sentiment.rs
@@ -105,17 +105,9 @@ impl SentimentModel {
     ///
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords, CustomStems};
+    /// use rnltk::sample_data;
     /// 
-    /// let custom_word_dict = r#"
-    /// {
-    ///     "abduction": {
-    ///         "word": "abduction",
-    ///         "stem": "abduct",
-    ///         "avg": [2.76, 5.53],
-    ///         "std": [2.06, 2.43]
-    ///     }
-    /// }"#;
-    /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
+    /// let custom_words_sentiment_hashmap: CustomWords = sample_data::get_sample_custom_word_dict();
     /// 
     /// let custom_stem_dict = r#"
     /// {
@@ -148,17 +140,9 @@ impl SentimentModel {
     ///
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
+    /// use rnltk::sample_data;
     /// 
-    /// let custom_word_dict = r#"
-    /// {
-    ///     "abduction": {
-    ///         "word": "abduction",
-    ///         "stem": "abduct",
-    ///         "avg": [2.76, 5.53],
-    ///         "std": [2.06, 2.43]
-    ///     }
-    /// }"#;
-    /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
+    /// let custom_words_sentiment_hashmap: CustomWords = sample_data::get_sample_custom_word_dict();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
     /// if sentiment.does_term_exist("abduction") {
@@ -179,17 +163,9 @@ impl SentimentModel {
     ///
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
+    /// use rnltk::sample_data;
     /// 
-    /// let custom_word_dict = r#"
-    /// {
-    ///     "abduction": {
-    ///         "word": "abduction",
-    ///         "stem": "abduct",
-    ///         "avg": [2.76, 5.53],
-    ///         "std": [2.06, 2.43]
-    ///     }
-    /// }"#;
-    /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
+    /// let custom_words_sentiment_hashmap: CustomWords = sample_data::get_sample_custom_word_dict();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
     /// let arousal = sentiment.get_raw_arousal("abduction");
@@ -225,17 +201,9 @@ impl SentimentModel {
     ///
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
+    /// use rnltk::sample_data;
     /// 
-    /// let custom_word_dict = r#"
-    /// {
-    ///     "abduction": {
-    ///         "word": "abduction",
-    ///         "stem": "abduct",
-    ///         "avg": [2.76, 5.53],
-    ///         "std": [2.06, 2.43]
-    ///     }
-    /// }"#;
-    /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
+    /// let custom_words_sentiment_hashmap: CustomWords = sample_data::get_sample_custom_word_dict();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
     /// let valence = sentiment.get_raw_valence("abduction");
@@ -271,17 +239,9 @@ impl SentimentModel {
     ///
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
+    /// use rnltk::sample_data;
     /// 
-    /// let custom_word_dict = r#"
-    /// {
-    ///     "abduction": {
-    ///         "word": "abduction",
-    ///         "stem": "abduct",
-    ///         "avg": [2.76, 5.53],
-    ///         "std": [2.06, 2.43]
-    ///     }
-    /// }"#;
-    /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
+    /// let custom_words_sentiment_hashmap: CustomWords = sample_data::get_sample_custom_word_dict();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
     /// let arousal = sentiment.get_arousal_for_single_term("abduction");
@@ -303,17 +263,9 @@ impl SentimentModel {
     ///
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
+    /// use rnltk::sample_data;
     /// 
-    /// let custom_word_dict = r#"
-    /// {
-    ///     "abduction": {
-    ///         "word": "abduction",
-    ///         "stem": "abduct",
-    ///         "avg": [2.76, 5.53],
-    ///         "std": [2.06, 2.43]
-    ///     }
-    /// }"#;
-    /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
+    /// let custom_words_sentiment_hashmap: CustomWords = sample_data::get_sample_custom_word_dict();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
     /// let valence = sentiment.get_valence_for_single_term("abduction");
@@ -454,17 +406,9 @@ impl SentimentModel {
     /// ```
     /// use std::collections::HashMap;
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
+    /// use rnltk::sample_data;
     /// 
-    /// let custom_word_dict = r#"
-    /// {
-    ///     "abduction": {
-    ///         "word": "abduction",
-    ///         "stem": "abduct",
-    ///         "avg": [2.76, 5.53],
-    ///         "std": [2.06, 2.43]
-    ///     }
-    /// }"#;
-    /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
+    /// let custom_words_sentiment_hashmap: CustomWords = sample_data::get_sample_custom_word_dict();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
     /// let sentiment_info = sentiment.get_sentiment_for_term("abduction");
@@ -534,17 +478,9 @@ impl SentimentModel {
     ///
     /// ```
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
+    /// use rnltk::sample_data;
     /// 
-    /// let custom_word_dict = r#"
-    /// {
-    ///     "abduction": {
-    ///         "word": "abduction",
-    ///         "stem": "abduct",
-    ///         "avg": [2.76, 5.53],
-    ///         "std": [2.06, 2.43]
-    ///     }
-    /// }"#;
-    /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
+    /// let custom_words_sentiment_hashmap: CustomWords = sample_data::get_sample_custom_word_dict();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
     /// let sentiment_description = sentiment.get_sentiment_description(&2.76, &5.53);
@@ -632,17 +568,9 @@ impl SentimentModel {
     /// ```
     /// use std::collections::HashMap;
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
+    /// use rnltk::sample_data;
     /// 
-    /// let custom_word_dict = r#"
-    /// {
-    ///     "abduction": {
-    ///         "word": "abduction",
-    ///         "stem": "abduct",
-    ///         "avg": [2.76, 5.53],
-    ///         "std": [2.06, 2.43]
-    ///     }
-    /// }"#;
-    /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
+    /// let custom_words_sentiment_hashmap: CustomWords = sample_data::get_sample_custom_word_dict();
     /// 
     /// let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
     /// let sentiment_description = sentiment.get_term_description("abduction");
@@ -719,17 +647,9 @@ impl SentimentModel {
     /// use std::collections::HashMap;
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// use rnltk::error::RnltkError;
+    /// use rnltk::sample_data;
     /// 
-    /// let custom_word_dict = r#"
-    /// {
-    ///     "abduction": {
-    ///         "word": "abduction",
-    ///         "stem": "abduct",
-    ///         "avg": [2.76, 5.53],
-    ///         "std": [2.06, 2.43]
-    ///     }
-    /// }"#;
-    /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
+    /// let custom_words_sentiment_hashmap: CustomWords = sample_data::get_sample_custom_word_dict();
     /// 
     /// let mut sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
     /// let sentiment_return_value = sentiment.add_term_without_replacement("squanch", &2.0, &8.5);
@@ -791,17 +711,9 @@ impl SentimentModel {
     /// use std::collections::HashMap;
     /// use rnltk::sentiment::{SentimentModel, CustomWords};
     /// use rnltk::error::RnltkError;
+    /// use rnltk::sample_data;
     /// 
-    /// let custom_word_dict = r#"
-    /// {
-    ///     "abduction": {
-    ///         "word": "abduction",
-    ///         "stem": "abduct",
-    ///         "avg": [2.76, 5.53],
-    ///         "std": [2.06, 2.43]
-    ///     }
-    /// }"#;
-    /// let custom_words_sentiment_hashmap: CustomWords = serde_json::from_str(custom_word_dict).unwrap();
+    /// let custom_words_sentiment_hashmap: CustomWords = sample_data::get_sample_custom_word_dict();
     /// 
     /// let mut sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
     /// let sentiment_return_value = sentiment.add_term_with_replacement("abduction", &8.0, &8.5);


### PR DESCRIPTION
- Changed TOML snippet from `ignore` to `toml`
- Changed doc examples of strings with escaped characters to raw strings and moved them to the `sample_data.rs` module
- Updated `RnltkError` to impl `std::error::Error` with `thiserror` crate
- Added `RawSentiment` struct to hold return values for raw valence and arousal
- Removed "Arguments" section from function documentation