### PR TITLE
TF-IDF

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustdocflags = [ "--html-in-header", "./src/docs-header.html" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 documentation = "https://docs.rs/rnltk"
 repository = "https://github.com/michael-long88/rnltk/"
 
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -19,3 +18,4 @@ serde_json = "1.0.86"
 regex = "1.6.0"
 csv = "1.1.6"
 thiserror = "1.0.37"
+nalgebra = "0.31.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/michael-long88/rnltk/"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[package.metadata.docs.rs]
+rustdoc-args = [ "--html-in-header", "./src/docs-header.html" ]
+
 [dependencies]
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.86"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Stemming currently uses modified code from [rust-stem](https://github.com/minhnh
 
 More information on the stemming algorithm can be found [here](https://tartarus.org/martin/PorterStemmer/).
 
+## TF-IDF
+Term frequency–inverse document frequency (TF-IDF) is an algorithm used to find document similarity. Creating a TF-IDF matrix takes place over two steps:
+1. Apply a weight, $w_{i,j}$, for every term, $t_i$, in the document, $D_j$. $w_{i,j}$ is defined as $tf_{i,j} \times idf_i$, where $tf_{i,j}$ is the number of occurrences of $t_i$ in $D_j$, and $idf_i$ is the log of inverse fraction of documents $n_i$ that contain at least one occurrence of $t_i, idf_i = ln(\frac{n}{n_i})$.
+1. Take the weighted matrix and then normalize each document vector in order to remove the influence of document length.
+
+The weighted, normalized matrix can then be used to find the cosine similarity between documents. 
+Normally, calculating the cosine similarity of two document vectors would look like $\cos \theta = \frac{D_i \cdot D_j}{|D_i| |D_j|}$. Since the matrix is already normalized, this simplifies to $\cos \theta = D_i \cdot D_j$. 
+
+The resulting $MxM$ matrix, where $M$ is the number of columns from the TF-IDF matrix, has 1's along the diagonal since the similarity of a document with itself is 1. The intersections of rows and columns, $M_{i,j}$, is the cosine similarity value between $D_i$ and $D_j$.
+
 ## Roadmap
 * article summary (based on term frequency)
 * topic clustering

--- a/examples/document_similarity.rs
+++ b/examples/document_similarity.rs
@@ -26,8 +26,9 @@ fn main() {
     let document_term_frequencies = DMatrix::from_vec(nrows, ncols, all_term_frequencies);
 
     let document_term_frequency_matrix = document::DocumentTermFrequencies::new(document_term_frequencies);
-    let tfidf_matrix = document_term_frequency_matrix.get_tfidf();
-    let cosine_similarity_matrix = tfidf_matrix.get_cosine_similarity_from_tfidf().cosine_similarity_matrix;
+    let tfidf_matrix = document_term_frequency_matrix.get_tfidf_from_term_frequencies();
+    let cosine_similarity = tfidf_matrix.get_cosine_similarity_from_tfidf();
+    let cosine_similarity_matrix = cosine_similarity.get_cosine_similarity_matrix();
 
     for row_index in 0..ncols {
         println!(

--- a/examples/document_similarity.rs
+++ b/examples/document_similarity.rs
@@ -1,0 +1,43 @@
+//! Create a document similarity matrix from four documents
+
+use rnltk::{document, token};
+use nalgebra::{DMatrix};
+
+
+fn main() {
+    let document1 = "It is a far, far better thing I do, than I have ever done";
+    let document2 = "Call me Ishmael";
+    let document3 = "Is this a dagger I see before me?";
+    let document4 = "O happy dagger";
+
+    let documents = vec![document1, document2, document3, document4];
+
+    let documents_term_frequencies = token::get_term_frequencies_from_sentences(&documents);
+
+    let mut all_term_frequencies: Vec<f64> = vec![];
+
+    documents_term_frequencies.iter().for_each(|term_frequencies| {
+        all_term_frequencies.extend(term_frequencies.values().into_iter());
+    });
+
+    let nrows = documents_term_frequencies[0].values().len();
+    let ncols = documents.len();
+
+    let document_term_frequencies = DMatrix::from_vec(nrows, ncols, all_term_frequencies);
+
+    let document_term_frequency_matrix = document::DocumentTermFrequencies::new(document_term_frequencies);
+    let tfidf_matrix = document_term_frequency_matrix.get_tfidf();
+    let cosine_similarity_matrix = tfidf_matrix.get_cosine_similarity_from_tfidf().cosine_similarity_matrix;
+
+    for row_index in 0..ncols {
+        println!(
+            "Document {}          {:.2}          {:.2}          {:.2}          {:.2}",
+            row_index + 1,
+            &cosine_similarity_matrix[(row_index, 0)],
+            &cosine_similarity_matrix[(row_index, 1)],
+            &cosine_similarity_matrix[(row_index, 2)],
+            &cosine_similarity_matrix[(row_index, 3)]
+        )
+    }
+    println!("              Document 1    Document 2    Document 3    Document 4");
+}

--- a/examples/lexicon_creation.rs
+++ b/examples/lexicon_creation.rs
@@ -16,12 +16,12 @@ fn main() {
     for record in reader.records() {
         let record = record.unwrap();
         let word = record[1].to_owned();
+
         let stemmed_word = stem::get(&word).unwrap();
-        if &word == "betrayal" {
-            println!("{:?}", &stemmed_word)
-        }
+
         let avg = vec![record[2].parse::<f64>().unwrap(), record[5].parse::<f64>().unwrap()];
         let std = vec![record[3].parse::<f64>().unwrap(), record[6].parse::<f64>().unwrap()];
+        
         let sentiment_dict = SentimentDictValue::new(word, stemmed_word, avg, std);
         custom_words.insert(record[1].to_owned(), sentiment_dict);
     }

--- a/src/docs-header.html
+++ b/src/docs-header.html
@@ -1,0 +1,16 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.css" integrity="sha384-9eLZqc9ds8eNjO3TmqPeYcDj8n+Qfa4nuSiGYa6DjLNcv9BtN69ZIulL9+8CqC9Y" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.js"                  integrity="sha384-K3vbOmF2BtaVai+Qk37uypf7VrgBubhQreNQe9aGsz9lB63dIFiQVlJbr92dw2Lx" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/contrib/auto-render.min.js"    integrity="sha384-kmZOZB5ObwgQnS/DuDg6TScgOiWWBiVt0plIRkZCmE6rDZGrEOQeHM5PcHi+nyqe" crossorigin="anonymous"></script>
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        renderMathInElement(document.body, {
+            delimiters: [
+                {left: "$$", right: "$$", display: true},
+                {left: "\\(", right: "\\)", display: false},
+                {left: "$", right: "$", display: false},
+                {left: "\\[", right: "\\]", display: true},
+                {left: "\\(", right: "\\)", display: false}
+            ]
+        });
+    });
+</script>

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,0 +1,182 @@
+//! Functionality for performing matrix operations on document term frequencies.
+
+use nalgebra::{Matrix, Dynamic, VecStorage};
+
+pub type GenericMatrix = Matrix<f64, Dynamic, Dynamic, VecStorage<f64, Dynamic, Dynamic>>;
+
+/// Struct for holding the matrix of `document_term_frequencies`
+pub struct DocumentTermFrequencies {
+    pub document_term_frequencies: GenericMatrix
+}
+
+/// Struct for holding the resulting `tfidf_matrix`
+/// from [`DocumentTermFrequencies::get_tfidf`]
+pub struct TfidfMatrix {
+    pub tfidf_matrix: GenericMatrix
+}
+
+/// Struct for holding the resulting `cosine_similarity_matrix`
+/// from [`TfidfMatrix::get_cosine_similarity_from_tfidf`]
+pub struct CosineSimilarityMatrix {
+    pub cosine_similarity_matrix: GenericMatrix
+}
+
+impl DocumentTermFrequencies {
+    /// Creates new instance of DocumentTermFrequencies from a [`DMatrix`].
+    /// 
+    /// [`DMatrix`]: nalgebra::DMatrix
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rnltk::document::DocumentTermFrequencies;
+    /// use nalgebra::DMatrix;
+    /// 
+    /// let term_frequencies = DMatrix::from_row_slice(11, 4, &[1., 0., 0., 0.,
+    ///     0., 1., 0., 0.,
+    ///     0., 0., 1., 1.,
+    ///     1., 0., 0., 0.,
+    ///     1., 0., 0., 0.,
+    ///     2., 0., 0., 0.,
+    ///     0., 0., 0., 1.,
+    ///     0., 1., 0., 0.,
+    ///     0., 0., 0., 1.,
+    ///     0., 0., 1., 0.,
+    ///     1., 0., 0., 0.,]);
+    /// 
+    /// let document_term_frequencies: DocumentTermFrequencies = DocumentTermFrequencies::new(term_frequencies);
+    /// ```
+    pub fn new(document_term_frequencies: GenericMatrix) -> Self {
+        DocumentTermFrequencies {
+            document_term_frequencies
+        }
+    }
+
+    /// Gets the Term Frequency–Inverse Document Frequency (TF-IDF) matrix of the 
+    /// [`DocumentTermFrequencies`]'s `document_term_frequencies`.
+    /// 
+    /// Creating a TF-IDF matrix takes place over two steps. 
+    /// The first step is applying a weight, \\(w_{i,j}\\), for every term, \\(t_i\\), 
+    /// in the document, \\(D_j\\). \\(w_{i,j}\\) is defined as \\(tf_{i,j} \times idf_i\\), 
+    /// where \\(tf_{i,j}\\) is the number of occurrences of \\(t_i\\) in \\(D_j\\), and 
+    /// \\(idf_i\\) is the log of inverse fraction of documents \\(n_i\\) that contain at least one 
+    /// occurrence of \\(t_i, idf_i = ln(n / n_i)\\).
+    /// The second step takes the weighted matrix and then normalizes each document vector in order
+    /// to remove the influence of document length.
+    ///
+    /// # Examples
+    /// 
+    /// ```
+    /// use rnltk::document::DocumentTermFrequencies;
+    /// use rnltk::sample_data;
+    /// 
+    /// let document_term_frequencies: DocumentTermFrequencies = DocumentTermFrequencies::new(sample_data::get_term_frequencies());
+    /// let tfidf_matrix = document_term_frequencies.get_tfidf();
+    /// ```
+    pub fn get_tfidf(&self) -> TfidfMatrix {
+        let mut document_term_frequencies = self.document_term_frequencies.clone();
+        for row_index in 0..document_term_frequencies.nrows() {
+            let term_count: f64 = document_term_frequencies.row(row_index).iter().fold(0., |acc, frequency| {
+                if frequency > &0. {
+                    acc + 1.
+                } else {
+                    acc
+                }
+            });
+            for col_index in 0..document_term_frequencies.ncols() {
+                let term_frequency = &document_term_frequencies[(row_index, col_index)];
+                let inverse_document_frequency = (document_term_frequencies.ncols() as f64 / term_count).ln();
+                document_term_frequencies[(row_index, col_index)] = term_frequency * inverse_document_frequency;
+            }
+        }
+    
+        for mut column in document_term_frequencies.column_iter_mut() {
+            let normalized = column.normalize();
+            column.copy_from(&normalized);
+        }
+    
+        TfidfMatrix {
+            tfidf_matrix: document_term_frequencies
+        }
+    }
+}
+
+impl TfidfMatrix {
+    /// Gets the cosine similarity matrix from the [`TfidfMatrix`]'s `tfidf_matrix`.
+    /// 
+    /// Normally, calculating the cosine similarity of two document vectors would look like
+    /// \\(\cos \theta = \frac{D_i \cdot D_j}{|D_i| |D_j|}\\). Since the TF-IDF matrix returned
+    /// from [`DocumentTermFrequencies::get_tfidf`] is already normalized, this simplifies
+    /// to \\(\cos \theta = D_i \cdot D_j\\). 
+    /// 
+    /// The resulting matrix has 1's along the diagonal since the similarity of a document
+    /// with itself is 1. The intersections of rows and columns, \\(M_{i,j}\\), is the cosine 
+    /// similarity value between \\(D_i\\) and \\(D_j\\).
+    ///
+    /// # Examples
+    /// 
+    /// ```
+    /// use rnltk::document::DocumentTermFrequencies;
+    /// use rnltk::sample_data;
+    /// 
+    /// let document_term_frequencies: DocumentTermFrequencies = DocumentTermFrequencies::new(sample_data::get_term_frequencies());
+    /// let tfidf_matrix = document_term_frequencies.get_tfidf();
+    /// let cosine_similarity_matrix = tfidf_matrix.get_cosine_similarity_from_tfidf();
+    /// ```
+    pub fn get_cosine_similarity_from_tfidf(&self) -> CosineSimilarityMatrix {
+        let num_cols = self.tfidf_matrix.ncols();
+        let mut cosine_similarity_matrix: GenericMatrix = GenericMatrix::zeros(num_cols, num_cols);
+        for col_index in 0..num_cols {
+            for inner_col_index in 0..num_cols {
+                if col_index == inner_col_index {
+                    cosine_similarity_matrix[(col_index, inner_col_index)] = 1.
+                } else {
+                    let dot_product = self.tfidf_matrix.column(col_index).dot(&self.tfidf_matrix.column(inner_col_index));
+                    cosine_similarity_matrix[(col_index, inner_col_index)] = dot_product
+                }
+            }
+        }
+    
+        CosineSimilarityMatrix {
+            cosine_similarity_matrix
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f64::consts::FRAC_1_SQRT_2;
+    use nalgebra::{DMatrix};
+    use crate::sample_data;
+    
+    #[test]
+    fn tfidf() {
+        let document_term_frequencies: DocumentTermFrequencies = DocumentTermFrequencies::new(sample_data::get_term_frequencies());
+        let tfidf_matrix= DMatrix::from_row_slice(11, 4, &[0.3535533905932738, 0., 0., 0.,
+                                                                            0., FRAC_1_SQRT_2, 0., 0.,
+                                                                            0., 0., 0.447213595499958, 0.33333333333333337,
+                                                                            0.3535533905932738, 0., 0., 0.,
+                                                                            0.3535533905932738, 0., 0., 0.,
+                                                                            FRAC_1_SQRT_2, 0., 0., 0.,
+                                                                            0., 0., 0., 0.6666666666666667,
+                                                                            0., FRAC_1_SQRT_2, 0., 0.,
+                                                                            0., 0., 0., 0.6666666666666667,
+                                                                            0., 0., 0.894427190999916, 0.,
+                                                                            0.3535533905932738, 0., 0., 0.,]);
+        let output = document_term_frequencies.get_tfidf();
+        assert_eq!(output.tfidf_matrix, tfidf_matrix);
+    }
+
+    #[test]
+    fn cosine_similarity() {
+        let document_term_frequencies: DocumentTermFrequencies = DocumentTermFrequencies::new(sample_data::get_term_frequencies());
+        let tfidf_matrix = document_term_frequencies.get_tfidf();
+        let cosine_similarity_matrix = DMatrix::from_row_slice(4, 4, &[1., 0., 0., 0.,
+                                                                                            0., 1., 0., 0.,
+                                                                                            0., 0., 1., 0.149071198499986,
+                                                                                            0., 0., 0.149071198499986, 1.,]);
+        let output = tfidf_matrix.get_cosine_similarity_from_tfidf();
+        assert_eq!(output.cosine_similarity_matrix, cosine_similarity_matrix);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //! let sentiment = SentimentModel::new(custom_words_sentiment_hashmap);
 //! ```
 //! 
-//! Checkout the examples folder in the github project repository for a more comprehensive example.
+//! Checkout the examples folder in the github project repository for more comprehensive examples.
 //! 
 
 pub mod token;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,3 +56,4 @@ pub mod sentiment;
 pub mod stem;
 pub mod error;
 pub mod sample_data;
+pub mod document;

--- a/src/sample_data.rs
+++ b/src/sample_data.rs
@@ -1,9 +1,9 @@
-//! Module containing function to get [`CustomWords`] struct primarily
-//! for the use in documentation.
-//! 
-//! [`CustomWords`]: ./sentiment/type.CustomWords.html
+//! Module containing functions to retrieve sample data for
+//! use in the main modules.
 
 use crate::sentiment::CustomWords;
+use crate::document::GenericMatrix;
+use nalgebra::DMatrix;
 
 
 pub fn get_sample_custom_word_dict() -> CustomWords {
@@ -30,4 +30,18 @@ pub fn get_sample_custom_word_dict() -> CustomWords {
     }"#;
 
     serde_json::from_str(custom_word_dict).unwrap()
+}
+
+pub fn get_term_frequencies() -> GenericMatrix {
+    DMatrix::from_row_slice(11, 4, &[1., 0., 0., 0.,
+        0., 1., 0., 0.,
+        0., 0., 1., 1.,
+        1., 0., 0., 0.,
+        1., 0., 0., 0.,
+        2., 0., 0., 0.,
+        0., 0., 0., 1.,
+        0., 1., 0., 0.,
+        0., 0., 0., 1.,
+        0., 0., 1., 0.,
+        1., 0., 0., 0.,])
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,17 +1,13 @@
 //! Module containing functions used to tokenize strings and get term frequencies.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use regex::Regex;
 
 
 const STOP_WORDS: &[&str] = &["i", "me", "my", "myself", "we", "our", "ours", "ourselves", "you", "you're", "you've", "you'll", "you'd", "your", "yours", "yourself", "yourselves", "he", "him", "his", "himself", "she", "she's", "her", "hers", "herself", "it", "it's", "its", "itself", "they", "them", "their", "theirs", "themselves", "what", "which", "who", "whom", "this", "that", "that'll", "these", "those", "am", "is", "are", "was", "were", "be", "been", "being", "have", "has", "had", "having", "do", "does", "did", "doing", "a", "an", "the", "and", "but", "if", "or", "because", "as", "until", "while", "of", "at", "by", "for", "with", "about", "against", "between", "into", "through", "during", "before", "after", "above", "below", "to", "from", "up", "down", "in", "out", "on", "off", "over", "under", "again", "further", "then", "once", "here", "there", "when", "where", "why", "how", "all", "any", "both", "each", "few", "more", "most", "other", "some", "such", "no", "nor", "not", "only", "own", "same", "so", "than", "too", "very", "s", "t", "can", "will", "just", "don", "don't", "should", "should've", "now", "d", "ll", "m", "o", "re", "ve", "y", "ain", "aren", "aren't", "couldn", "couldn't", "didn", "didn't", "doesn", "doesn't", "hadn", "hadn't", "hasn", "hasn't", "haven", "haven't", "isn", "isn't", "ma", "mightn", "mightn't", "mustn", "mustn't", "needn", "needn't", "shan", "shan't", "shouldn", "shouldn't", "wasn", "wasn't", "weren", "weren't", "won", "won't", "wouldn", "wouldn't"];
 
-/// Converts documents to sentence vector.
-/// 
-/// # Arguments
-/// 
-/// * `document` - A &str representation of the text document.
+/// Converts a `document` to sentence vector.
 ///
 /// # Examples
 ///
@@ -35,11 +31,7 @@ pub fn tokenize_into_sentences(document: &str) -> Vec<String> {
     full_sentences
 }
 
-/// Converts sentence to token vector.
-/// 
-/// # Arguments
-/// 
-/// * `sentence` - A &str representation of the sentence.
+/// Converts `sentence` to token vector.
 ///
 /// # Examples
 ///
@@ -62,52 +54,44 @@ pub fn tokenize_sentence(sentence: &str) -> Vec<String> {
     tokens
 }
 
-/// Gets a count of all words from a term vector.
-/// 
-/// # Arguments
-/// 
-/// * `word_tokens` - A &str vector containing words to be counted
+/// Gets a count of all words from a vector of `word_tokens`.
 ///
 /// # Examples
 ///
 /// ```
-/// use std::collections::HashMap;
+/// use std::collections::BTreeMap;
 /// use rnltk::token;
 /// 
 /// let arg = vec!["fear", "leads", "to", "anger", "anger", "leads", "to", "hatred", "hatred", "leads", "to", "conflict", "conflict", "leads", "to", "suffering"];
-/// let word_counts = HashMap::from([("fear".to_string(), 1), ("leads".to_string(), 4), ("to".to_string(), 4), ("anger".to_string(), 2), ("hatred".to_string(), 2), ("conflict".to_string(), 2), ("suffering".to_string(), 1)]);
+/// let word_counts = BTreeMap::from([("fear".to_string(), 1.), ("leads".to_string(), 4.), ("to".to_string(), 4.), ("anger".to_string(), 2.), ("hatred".to_string(), 2.), ("conflict".to_string(), 2.), ("suffering".to_string(), 1.)]);
 /// let term_frequencies = token::get_term_frequencies_from_word_vector(arg);
 ///
 /// assert_eq!(word_counts, term_frequencies);
 /// ```
-pub fn get_term_frequencies_from_word_vector(word_tokens: Vec<&str>) -> HashMap<String, u32> {
-    let mut word_counts: HashMap<String, u32> = HashMap::new();
+pub fn get_term_frequencies_from_word_vector(word_tokens: Vec<&str>) -> BTreeMap<String, f64> {
+    let mut word_counts: BTreeMap<String, f64> = BTreeMap::new();
     for word in word_tokens {
-        let count = word_counts.entry(word.to_string()).or_insert(0);
-        *count += 1;
+        let count = word_counts.entry(word.to_string()).or_insert(0.);
+        *count += 1.;
     }
     word_counts
 }
 
-/// Gets a count of all words from a sentence.
-/// 
-/// # Arguments
-/// 
-/// * `sentence` - A &str representation of the sentence to be tokenized and counted
+/// Gets a count of all words from a `sentence`.
 ///
 /// # Examples
 ///
 /// ```
-/// use std::collections::HashMap;
+/// use std::collections::BTreeMap;
 /// use rnltk::token;
 /// 
 /// let sentence = "fear leads to anger, anger leads to hatred, hatred leads to conflict, conflict leads to suffering.";
-/// let word_counts = HashMap::from([("fear".to_string(), 1), ("leads".to_string(), 4), ("to".to_string(), 4), ("anger".to_string(), 2), ("hatred".to_string(), 2), ("conflict".to_string(), 2), ("suffering".to_string(), 1)]);
+/// let word_counts = BTreeMap::from([("fear".to_string(), 1.), ("leads".to_string(), 4.), ("to".to_string(), 4.), ("anger".to_string(), 2.), ("hatred".to_string(), 2.), ("conflict".to_string(), 2.), ("suffering".to_string(), 1.)]);
 /// let term_frequencies = token::get_term_frequencies_from_sentence(sentence);
 ///
 /// assert_eq!(word_counts, term_frequencies);
 /// ```
-pub fn get_term_frequencies_from_sentence(sentence: &str) -> HashMap<String, u32> {
+pub fn get_term_frequencies_from_sentence(sentence: &str) -> BTreeMap<String, f64> {
     let sentence_tokens = tokenize_sentence(sentence);
     let sentence_tokens: Vec<&str> = sentence_tokens.iter().map(|s| s.as_str()).collect();
     get_term_frequencies_from_word_vector(sentence_tokens)
@@ -136,7 +120,7 @@ mod tests {
     #[test]
     fn test_term_frequencies_from_str_vector() {
         let tokens = vec!["fear", "leads", "to", "anger", "anger", "leads", "to", "hatred", "hatred", "leads", "to", "conflict", "conflict", "leads", "to", "suffering"];
-        let word_counts = HashMap::from([("fear".to_string(), 1), ("leads".to_string(), 4), ("to".to_string(), 4), ("anger".to_string(), 2), ("hatred".to_string(), 2), ("conflict".to_string(), 2), ("suffering".to_string(), 1)]);
+        let word_counts = BTreeMap::from([("fear".to_string(), 1.), ("leads".to_string(), 4.), ("to".to_string(), 4.), ("anger".to_string(), 2.), ("hatred".to_string(), 2.), ("conflict".to_string(), 2.), ("suffering".to_string(), 1.)]);
         let term_frequencies = get_term_frequencies_from_word_vector(tokens);
         assert_eq!(word_counts, term_frequencies);
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -97,6 +97,48 @@ pub fn get_term_frequencies_from_sentence(sentence: &str) -> BTreeMap<String, f6
     get_term_frequencies_from_word_vector(sentence_tokens)
 }
 
+/// Gets a count of all words from a vector of `sentence`s.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::BTreeMap;
+/// use rnltk::token;
+/// 
+/// let sentences = vec!["fear leads to anger", "anger leads to hatred", "hatred leads to conflict", "conflict leads to suffering."];
+/// let word_counts1 = BTreeMap::from([
+///     ("fear".to_string(), 1.), ("leads".to_string(), 1.), ("to".to_string(), 1.), ("anger".to_string(), 1.), ("hatred".to_string(), 0.), ("conflict".to_string(), 0.), ("suffering".to_string(), 0.)
+/// ]);
+/// let word_counts2 = BTreeMap::from([
+///     ("fear".to_string(), 0.), ("leads".to_string(), 1.), ("to".to_string(), 1.), ("anger".to_string(), 1.), ("hatred".to_string(), 1.), ("conflict".to_string(), 0.), ("suffering".to_string(), 0.)
+/// ]);
+/// let word_counts3 = BTreeMap::from([
+///     ("fear".to_string(), 0.), ("leads".to_string(), 1.), ("to".to_string(), 1.), ("anger".to_string(), 0.), ("hatred".to_string(), 1.), ("conflict".to_string(),1.), ("suffering".to_string(), 0.)
+/// ]);
+/// let word_counts4 = BTreeMap::from([
+///     ("fear".to_string(), 0.), ("leads".to_string(), 1.), ("to".to_string(), 1.), ("anger".to_string(), 0.), ("hatred".to_string(), 0.), ("conflict".to_string(), 1.), ("suffering".to_string(), 1.)
+/// ]);
+/// let term_frequencies = token::get_term_frequencies_from_sentences(&sentences);
+///
+/// assert_eq!(vec![word_counts1, word_counts2, word_counts3, word_counts4], term_frequencies);
+/// ```
+pub fn get_term_frequencies_from_sentences(sentences: &[&str]) -> Vec<BTreeMap<String, f64>> {
+    let mut total_terms: Vec<String> = vec![];
+    let mut term_frequencies: Vec<BTreeMap<String, f64>> = sentences.iter().map(|sentence| {
+        let frequencies = get_term_frequencies_from_sentence(sentence);
+        total_terms.extend(frequencies.keys().cloned().collect::<Vec<String>>());
+        frequencies
+    }).collect();
+    for frequency_counts in &mut term_frequencies {
+        for term in &total_terms {
+            if !frequency_counts.contains_key(term) {
+                frequency_counts.insert(term.to_string(), 0.);
+            }
+        }
+    }
+    term_frequencies
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -123,5 +165,25 @@ mod tests {
         let word_counts = BTreeMap::from([("fear".to_string(), 1.), ("leads".to_string(), 4.), ("to".to_string(), 4.), ("anger".to_string(), 2.), ("hatred".to_string(), 2.), ("conflict".to_string(), 2.), ("suffering".to_string(), 1.)]);
         let term_frequencies = get_term_frequencies_from_word_vector(tokens);
         assert_eq!(word_counts, term_frequencies);
+    }
+
+    #[test]
+    fn test_term_frequencies_from_sentences() {
+        let sentences = vec!["fear leads to anger", "anger leads to hatred", "hatred leads to conflict", "conflict leads to suffering."];
+        let word_counts1 = BTreeMap::from([
+            ("fear".to_string(), 1.), ("leads".to_string(), 1.), ("to".to_string(), 1.), ("anger".to_string(), 1.), ("hatred".to_string(), 0.), ("conflict".to_string(), 0.), ("suffering".to_string(), 0.)
+        ]);
+        let word_counts2 = BTreeMap::from([
+            ("fear".to_string(), 0.), ("leads".to_string(), 1.), ("to".to_string(), 1.), ("anger".to_string(), 1.), ("hatred".to_string(), 1.), ("conflict".to_string(), 0.), ("suffering".to_string(), 0.)
+        ]);
+        let word_counts3 = BTreeMap::from([
+            ("fear".to_string(), 0.), ("leads".to_string(), 1.), ("to".to_string(), 1.), ("anger".to_string(), 0.), ("hatred".to_string(), 1.), ("conflict".to_string(),1.), ("suffering".to_string(), 0.)
+        ]);
+        let word_counts4 = BTreeMap::from([
+            ("fear".to_string(), 0.), ("leads".to_string(), 1.), ("to".to_string(), 1.), ("anger".to_string(), 0.), ("hatred".to_string(), 0.), ("conflict".to_string(), 1.), ("suffering".to_string(), 1.)
+        ]);
+        let term_frequencies = get_term_frequencies_from_sentences(&sentences);
+        
+        assert_eq!(vec![word_counts1, word_counts2, word_counts3, word_counts4], term_frequencies);
     }
 }


### PR DESCRIPTION
Adding ability to do matrix operations on document term frequencies
- Added function to get term frequencies from a vector of sentences
  - Note: every `BTreeMap` returned will have a frequency key for *every* term present between all sentences
- Changed instances of `HashMap` to `BTreeMap` to maintain the same key order between each set of term frequencies
  - Need to have the same key order when creating the TF-IDF matrix
- Added new `document` module
  - Added function to create normalized, weighted TF-IDF matrix from document term frequencies
  - Added function to get cosine similarity matrix from normalized, weighted TF-IDF matrix
- Added support for latex in documentation
  - Need to run `cargo rustdoc --open` to view
- Added new example file for creating a cosine similarity matrix